### PR TITLE
feat: seperate `Look` as a derive macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
-
+*/target
 
 # Added by cargo
 #

--- a/see_derive/src/inner.rs
+++ b/see_derive/src/inner.rs
@@ -8,7 +8,7 @@ static FIELDS: sync::Mutex<Vec<String>> = sync::Mutex::new(Vec::new());
 pub(crate) fn see_derive(input: DeriveInput, look: bool) -> Result<TokenStream, syn::Error> {
     let look = match look {
         true => quote! { all() },
-        false => quote! { not(all()) }
+        false => quote! { not(all()) },
     };
 
     let name = &input.ident;

--- a/see_derive/src/inner.rs
+++ b/see_derive/src/inner.rs
@@ -5,7 +5,12 @@ use syn::{spanned::Spanned, DeriveInput};
 
 static FIELDS: sync::Mutex<Vec<String>> = sync::Mutex::new(Vec::new());
 
-pub(crate) fn see_derive(input: DeriveInput) -> Result<TokenStream, syn::Error> {
+pub(crate) fn see_derive(input: DeriveInput, look: bool) -> Result<TokenStream, syn::Error> {
+    let look = match look {
+        true => quote! { all() },
+        false => quote! { not(all()) }
+    };
+
     let name = &input.ident;
     let fields = match input.data {
         syn::Data::Struct(syn::DataStruct {
@@ -22,7 +27,6 @@ pub(crate) fn see_derive(input: DeriveInput) -> Result<TokenStream, syn::Error> 
     };
     let (field, types) = split_iter(fields);
     let (old_f, new_f) = split_iter(field);
-
     Ok(quote! {
         #(
             impl See<crate::see_t::#new_f> for #name {
@@ -35,6 +39,8 @@ pub(crate) fn see_derive(input: DeriveInput) -> Result<TokenStream, syn::Error> 
                 }
             }
 
+
+            #[cfg(#look)]
             impl std::ops::Index<crate::see_t::#new_f> for #name {
                 type Output = #types;
 
@@ -43,6 +49,7 @@ pub(crate) fn see_derive(input: DeriveInput) -> Result<TokenStream, syn::Error> 
                 }
             }
 
+            #[cfg(#look)]
             impl std::ops::IndexMut<crate::see_t::#new_f> for #name {
                 fn index_mut(&mut self, index: crate::see_t::#new_f) -> &mut Self::Output {
                     <Self as See<crate::see_t::#new_f>>::set(self)

--- a/see_derive/src/lib.rs
+++ b/see_derive/src/lib.rs
@@ -31,7 +31,7 @@ pub fn see_derive(input: TokenStream) -> TokenStream {
 
 ///
 /// Derives the trait `Look` as well as `See`, `Look` trait has autoimplemenation
-/// 
+///
 /// ## Example
 /// ```rust
 /// #[derive(see_derive::Look)]
@@ -39,12 +39,12 @@ pub fn see_derive(input: TokenStream) -> TokenStream {
 ///     x: i32,
 ///     y: i32
 /// }
-/// 
+///
 /// The above example implements:
 /// - `See<crate::see_t::X>`, `Look<crate::see_t::X>`
 /// - `See<crate::see_t::Y>`, `Look<crate::see_t::Y>`
 /// ```
-/// 
+///
 #[proc_macro_derive(Look)]
 pub fn look_derive(input: TokenStream) -> TokenStream {
     match inner::see_derive(parse_macro_input!(input as DeriveInput), true) {

--- a/see_derive/src/lib.rs
+++ b/see_derive/src/lib.rs
@@ -7,7 +7,7 @@ use syn::{parse_macro_input, DeriveInput};
 mod inner;
 
 ///
-/// Extension of the trait `See`, providing auto implementation for `See`,
+/// Derives the trait `See`, providing auto implementation for `See`,
 /// while also combining the loading visitors into a single place.
 ///
 /// ## Example
@@ -18,11 +18,36 @@ mod inner;
 ///     y: i32
 /// }
 /// ```
-/// This above example implements `See<crate::see_t::__x>` and `See<crate::see_t::__y>` for the point struct
+/// This above example implements `See<crate::see_t::X>` and `See<crate::see_t::Y>` for the point struct
 ///
 #[proc_macro_derive(See)]
 pub fn see_derive(input: TokenStream) -> TokenStream {
-    match inner::see_derive(parse_macro_input!(input as DeriveInput)) {
+    match inner::see_derive(parse_macro_input!(input as DeriveInput), false) {
+        Ok(res) => res,
+        Err(err) => err.into_compile_error(),
+    }
+    .into()
+}
+
+///
+/// Derives the trait `Look` as well as `See`, `Look` trait has autoimplemenation
+/// 
+/// ## Example
+/// ```rust
+/// #[derive(see_derive::Look)]
+/// struct Vector {
+///     x: i32,
+///     y: i32
+/// }
+/// 
+/// The above example implements:
+/// - `See<crate::see_t::X>`, `Look<crate::see_t::X>`
+/// - `See<crate::see_t::Y>`, `Look<crate::see_t::Y>`
+/// ```
+/// 
+#[proc_macro_derive(Look)]
+pub fn look_derive(input: TokenStream) -> TokenStream {
+    match inner::see_derive(parse_macro_input!(input as DeriveInput), true) {
         Ok(res) => res,
         Err(err) => err.into_compile_error(),
     }

--- a/tests/macro-test.rs
+++ b/tests/macro-test.rs
@@ -1,13 +1,13 @@
-use see_derive::{Load, See};
+use see_derive::{Load, Look};
 use see_through::{Look, See};
 
-#[derive(See)]
+#[derive(Look)]
 struct Point {
     x: i32,
     y: i32,
 }
 
-#[derive(See)]
+#[derive(Look)]
 struct Vector {
     x: i32,
     y: i32,


### PR DESCRIPTION
## Description

This PR allows the derivation of the `See` trait without the overhead of `Look` specific implementations