### PR TITLE
feat: seperate Look as a derive macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
-
+*/target
 
 # Added by cargo
 #

--- a/see_derive/src/inner.rs
+++ b/see_derive/src/inner.rs
@@ -8,7 +8,7 @@ static FIELDS: sync::Mutex<Vec<String>> = sync::Mutex::new(Vec::new());
 pub(crate) fn see_derive(input: DeriveInput, look: bool) -> Result<TokenStream, syn::Error> {
     let look = match look {
         true => quote! { all() },
-        false => quote! { not(all()) }
+        false => quote! { not(all()) },
     };
 
     let name = &input.ident;

--- a/see_derive/src/inner.rs
+++ b/see_derive/src/inner.rs
@@ -62,6 +62,14 @@ pub(crate) fn see_derive(input: DeriveInput, look: bool) -> Result<TokenStream, 
 pub(crate) fn load_fields(input: DeriveInput) -> TokenStream {
     create_struct_stream(input.span())
 }
+pub(crate) fn auto_load() -> TokenStream {
+    let struct_stream = create_struct_stream(Span::call_site());
+    quote! {
+        pub(crate) mod see_t {
+            #struct_stream
+        }
+    }
+}
 
 fn field_consumer(idn: Ident) -> (Ident, Ident) {
     let mut store = FIELDS.lock().unwrap();

--- a/see_derive/src/inner.rs
+++ b/see_derive/src/inner.rs
@@ -5,7 +5,12 @@ use syn::{spanned::Spanned, DeriveInput};
 
 static FIELDS: sync::Mutex<Vec<String>> = sync::Mutex::new(Vec::new());
 
-pub(crate) fn see_derive(input: DeriveInput) -> Result<TokenStream, syn::Error> {
+pub(crate) fn see_derive(input: DeriveInput, look: bool) -> Result<TokenStream, syn::Error> {
+    let look = match look {
+        true => quote! { all() },
+        false => quote! { not(all()) }
+    };
+
     let name = &input.ident;
     let fields = match input.data {
         syn::Data::Struct(syn::DataStruct {
@@ -22,7 +27,6 @@ pub(crate) fn see_derive(input: DeriveInput) -> Result<TokenStream, syn::Error> 
     };
     let (field, types) = split_iter(fields);
     let (old_f, new_f) = split_iter(field);
-
     Ok(quote! {
         #(
             impl See<crate::see_t::#new_f> for #name {
@@ -35,6 +39,8 @@ pub(crate) fn see_derive(input: DeriveInput) -> Result<TokenStream, syn::Error> 
                 }
             }
 
+
+            #[cfg(#look)]
             impl std::ops::Index<crate::see_t::#new_f> for #name {
                 type Output = #types;
 
@@ -43,6 +49,7 @@ pub(crate) fn see_derive(input: DeriveInput) -> Result<TokenStream, syn::Error> 
                 }
             }
 
+            #[cfg(#look)]
             impl std::ops::IndexMut<crate::see_t::#new_f> for #name {
                 fn index_mut(&mut self, index: crate::see_t::#new_f) -> &mut Self::Output {
                     <Self as See<crate::see_t::#new_f>>::set(self)

--- a/see_derive/src/lib.rs
+++ b/see_derive/src/lib.rs
@@ -78,3 +78,8 @@ pub fn look_derive(input: TokenStream) -> TokenStream {
 pub fn load_fields(input: TokenStream) -> TokenStream {
     inner::load_fields(parse_macro_input!(input as DeriveInput)).into()
 }
+
+#[proc_macro]
+pub fn auto_load(_input: TokenStream) -> TokenStream {
+    inner::auto_load().into()
+}

--- a/see_derive/src/lib.rs
+++ b/see_derive/src/lib.rs
@@ -31,7 +31,7 @@ pub fn see_derive(input: TokenStream) -> TokenStream {
 
 ///
 /// Derives the trait `Look` as well as `See`, `Look` trait has autoimplemenation
-/// 
+///
 /// ## Example
 /// ```rust
 /// #[derive(see_derive::Look)]
@@ -39,12 +39,12 @@ pub fn see_derive(input: TokenStream) -> TokenStream {
 ///     x: i32,
 ///     y: i32
 /// }
-/// 
+///
 /// The above example implements:
 /// - `See<crate::see_t::X>`, `Look<crate::see_t::X>`
 /// - `See<crate::see_t::Y>`, `Look<crate::see_t::Y>`
 /// ```
-/// 
+///
 #[proc_macro_derive(Look)]
 pub fn look_derive(input: TokenStream) -> TokenStream {
     match inner::see_derive(parse_macro_input!(input as DeriveInput), true) {

--- a/see_derive/src/lib.rs
+++ b/see_derive/src/lib.rs
@@ -7,7 +7,7 @@ use syn::{parse_macro_input, DeriveInput};
 mod inner;
 
 ///
-/// Extension of the trait `See`, providing auto implementation for `See`,
+/// Derives the trait `See`, providing auto implementation for `See`,
 /// while also combining the loading visitors into a single place.
 ///
 /// ## Example
@@ -18,11 +18,36 @@ mod inner;
 ///     y: i32
 /// }
 /// ```
-/// This above example implements `See<crate::see_t::__x>` and `See<crate::see_t::__y>` for the point struct
+/// This above example implements `See<crate::see_t::X>` and `See<crate::see_t::Y>` for the point struct
 ///
 #[proc_macro_derive(See)]
 pub fn see_derive(input: TokenStream) -> TokenStream {
-    match inner::see_derive(parse_macro_input!(input as DeriveInput)) {
+    match inner::see_derive(parse_macro_input!(input as DeriveInput), false) {
+        Ok(res) => res,
+        Err(err) => err.into_compile_error(),
+    }
+    .into()
+}
+
+///
+/// Derives the trait `Look` as well as `See`, `Look` trait has autoimplemenation
+/// 
+/// ## Example
+/// ```rust
+/// #[derive(see_derive::Look)]
+/// struct Vector {
+///     x: i32,
+///     y: i32
+/// }
+/// 
+/// The above example implements:
+/// - `See<crate::see_t::X>`, `Look<crate::see_t::X>`
+/// - `See<crate::see_t::Y>`, `Look<crate::see_t::Y>`
+/// ```
+/// 
+#[proc_macro_derive(Look)]
+pub fn look_derive(input: TokenStream) -> TokenStream {
+    match inner::see_derive(parse_macro_input!(input as DeriveInput), true) {
         Ok(res) => res,
         Err(err) => err.into_compile_error(),
     }

--- a/tests/macro-test.rs
+++ b/tests/macro-test.rs
@@ -1,13 +1,13 @@
-use see_derive::{Load, See};
+use see_derive::{Load, Look};
 use see_through::{Look, See};
 
-#[derive(See)]
+#[derive(Look)]
 struct Point {
     x: i32,
     y: i32,
 }
 
-#[derive(See)]
+#[derive(Look)]
 struct Vector {
     x: i32,
     y: i32,

--- a/tests/macro-test.rs
+++ b/tests/macro-test.rs
@@ -1,5 +1,4 @@
-use see_derive::{Load, Look};
-use see_through::{Look, See};
+use see_through::{see_derive::Look, Look, See};
 
 #[derive(Look)]
 struct Point {
@@ -47,8 +46,10 @@ fn test_see() {
     assert_eq!(p1.y, 2);
 }
 
-pub(crate) mod see_t {
-    use super::Load;
-    #[derive(Load)]
-    struct _SeeT;
-}
+// pub(crate) mod see_t {
+//     use super::Load;
+//     #[derive(Load)]
+//     struct _SeeT;
+// }
+
+see_derive::auto_load!();


### PR DESCRIPTION
## Description

This introduces `auto_laod!()` while removing the need to add code to `Load` the supporting types manually. i.e.
```rust
pub(crate) mod see_t {
	#[derive(Load)]
	struct _SeeT;
}
``` 